### PR TITLE
Lock split panel to prevent zero size

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 	</organization>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<vaadin.version>7.6.5</vaadin.version>
+		<vaadin.version>7.7.4</vaadin.version>
 		<spreadsheet.version>1.3.0</spreadsheet.version>
 		<vaadin.charts.version>3.0.0</vaadin.charts.version>
 		<vaadin.plugin.version>${vaadin.version}</vaadin.plugin.version>

--- a/src/main/java/com/vaadin/addon/spreadsheet/demo/SpreadsheetDemoUI.java
+++ b/src/main/java/com/vaadin/addon/spreadsheet/demo/SpreadsheetDemoUI.java
@@ -96,6 +96,7 @@ public class SpreadsheetDemoUI extends UI implements ValueChangeListener {
     protected void init(VaadinRequest request) {
         HorizontalSplitPanel horizontalSplitPanel = new HorizontalSplitPanel();
         horizontalSplitPanel.setSplitPosition(300, Unit.PIXELS);
+        horizontalSplitPanel.setLocked(true);
         horizontalSplitPanel.addStyleName("main-layout");
 
         final Link github = new Link("Source code on Github",


### PR DESCRIPTION
This doesn't fix but prevents the issue reported in vaadin/spreadsheet#436
In current demo unlocking the split panel doesn't make much sense as its first container doesn't handle correctly the resizing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/spreadsheet-demo/5)
<!-- Reviewable:end -->
